### PR TITLE
feat: add UserRepository with Spring Data JPA

### DIFF
--- a/src/main/java/com/sergio/usermanagement/repository/UserRepository.java
+++ b/src/main/java/com/sergio/usermanagement/repository/UserRepository.java
@@ -2,7 +2,6 @@ package com.sergio.usermanagement.repository;
 
 import com.sergio.usermanagement.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
@@ -10,7 +9,6 @@ import java.util.Optional;
  * Interfaz de acceso a datos para la entidad User.
  * Proporciona las operaciones básicas CRUD gracias a heredar de JpaRepository
  */
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     /**

--- a/src/main/java/com/sergio/usermanagement/repository/UserRepository.java
+++ b/src/main/java/com/sergio/usermanagement/repository/UserRepository.java
@@ -1,0 +1,25 @@
+package com.sergio.usermanagement.repository;
+
+import com.sergio.usermanagement.models.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Interfaz de acceso a datos para la entidad User.
+ * Proporciona las operaciones básicas CRUD gracias a heredar de JpaRepository
+ */
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * Busca un usuario por su email
+     * Útil para procesos de login y validación de registros duplicados
+     *
+     * @param email Correo electrónico del usuario.
+     * @return Un optional que puede contener al usuario si existe
+     */
+    // Optional es una clase contenedora que puede contener un valor o estar vacía, evitando así el uso de null
+    Optional<User> findByEmail(String email);
+}


### PR DESCRIPTION
### Objetivo
Establecer la capa de persistencia para la entidad `User` mediante una interfaz de repositorio que gestione las operaciones CRUD automáticamente.

## # Cambios realizados
* Creación de la carpeta `/repository`.
* Implementación de la interfaz `UserRepository` extendiendo de `JpaRepository<User, Long>`.
* Adición del método de búsqueda personalizada `findByEmail` utilizando Query Methods de JPA.
* Uso de `Optional` para una gestión segura de valores nulos en las búsquedas.

### Verificación
* El proyecto compila correctamente.
* Spring Boot valida el mapeo de la entidad con el repositorio al arrancar.

Closes #5