### PR TITLE
feat: Add basic validation to User entity and custom 400 error handling

### DIFF
--- a/src/main/java/com/sergio/usermanagement/controller/UserController.java
+++ b/src/main/java/com/sergio/usermanagement/controller/UserController.java
@@ -3,11 +3,15 @@ package com.sergio.usermanagement.controller;
 import com.sergio.usermanagement.exceptions.UserNotFoundException;
 import com.sergio.usermanagement.models.User;
 import com.sergio.usermanagement.service.UserService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Controlador REST para gestionar las operaciones de usuarios.
@@ -49,7 +53,7 @@ public class UserController {
      */
     @PostMapping
     // @RequestBody indica a Spring que el JSON de la petición debe convertirse en objeto User.
-    public User createUser(@RequestBody User user) {
+    public User createUser(@Valid @RequestBody User user) {
         return userService.saveUser(user);
     }
 
@@ -70,12 +74,12 @@ public class UserController {
      * Endpoint para actualizar un usuario existente.
      * Ruta: PUT /api/users/id
      *
-     * @param id Id del usuario a actualizar.
+     * @param id   Id del usuario a actualizar.
      * @param user El usuario a actualizar.
      * @return El usuario actualizado.
      */
     @PutMapping("/{id}")
-    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User user) {
+    public ResponseEntity<User> updateUser(@PathVariable Long id, @Valid @RequestBody User user) {
         User updatedUser = userService.updateUser(id, user);
         return ResponseEntity.ok(updatedUser);
     }
@@ -103,5 +107,15 @@ public class UserController {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<String> handleUserNotFound(UserNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach((error) ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 }

--- a/src/main/java/com/sergio/usermanagement/models/User.java
+++ b/src/main/java/com/sergio/usermanagement/models/User.java
@@ -1,6 +1,7 @@
 package com.sergio.usermanagement.models;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
 
 /**
  * Entidad que representa a un usuario dentro del sistema.
@@ -25,18 +26,23 @@ public class User {
      * Nombre de usuario único y obligatorio. No puede ser nulo.
      */
     @Column(nullable = false, unique = true)
+    @NotBlank(message = "El nombre de usuario no puede estar vacío.")
     private String username;
 
     /**
      * Dirección de correo electrónico única y obligatoria. No puede ser nula.
      */
     @Column(nullable = false, unique = true)
+    @NotBlank(message = "El email del usuario no puede estar vacío.")
+    @Email
     private String email;
 
     /**
      * Contraseña encriptada del usuario.
      */
     @Column(nullable = false)
+    @NotBlank(message = "La contraseña del usuario no puede estar vacía.")
+    @Size(min = 6, message = "La contraseña debe tener al menos 6 caracteres.")
     private String password;
 
     /**


### PR DESCRIPTION
### Descripción
Se han implementado las validaciones básicas para la entidad de `User`, protegiendo el sistema contra el registro de datos vacíos, nulos o mal formateados en las peticiones del cliente.

### Cambios Realizados
- **Entity**:
  - Añadida la dependencia de validación en el proyecto.
  - Añadidas las anotaciones de validación en la clase `User.java` con `@NotBlank`, `@Email`, y `@Size` para restringir los campos `username`, `email` y `password`.
  - Personalizados los mensajes de error de cada restricción.
- **Controller & Error Handling (Logic)**:
  - Activada la interceptación de datos mediante la anotación `@Valid` en los parámetros de los métodos `createUser` (POST) y `updateUser` (PUT).
  - Creado un manejador de excepciones global (`@ExceptionHandler`) para capturar `MethodArgumentNotValidException`.
  - Refactorizada la respuesta de error mapeándola en un `Map<String, String>` para devolver un JSON limpio con el formato `campo: mensaje` y código `400 Bad Request`.

### Pruebas y Testing (Postman)
Se han verificado en local los escenarios de error, confirmando que la API no procesa datos erroneos y orienta al cliente sobre el fallo:
- [x] **POST /api/users**: Validación activa. Campos incorrectos o vacíos disparan un error controlado (400 Bad Request).
- [x] **PUT /api/users/{id}**: Validación activa. El intento de actualizar datos con formatos inválidos es interceptado y denegado (400 Bad Request).

### Evidencia Visual

<img width="1083" height="587" alt="image_2026-06-04_14-14-05" src="https://github.com/user-attachments/assets/d10ab79e-c4ee-4a1e-ad98-6957ef4cad20" />

<img width="1077" height="585" alt="image_2026-06-04_14-18-57" src="https://github.com/user-attachments/assets/9073eb90-3c3f-4e7c-8fd3-a8bfd8162e84" />

Closes #13