### PR TITLE
feat: centralize exception handling with GlobalExceptionHandler and ErrorResponse

### DIFF
--- a/src/main/java/com/sergio/usermanagement/controller/UserController.java
+++ b/src/main/java/com/sergio/usermanagement/controller/UserController.java
@@ -95,27 +95,4 @@ public class UserController {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
-
-    /**
-     * Manejador de excepciones para UserNotFoundException.
-     * Intercepta el error cuando el usuario no existe y transforma la respuesta
-     * en un estado HTTP 404 Not Found con el mensaje de error correspondiente.
-     *
-     * @param ex La excepción capturada que contiene el mensaje de error.
-     * @return ResponseEntity con el mensaje de error en texto y el código 404.
-     */
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<String> handleUserNotFound(UserNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        Map<String, String> errors = new HashMap<>();
-
-        ex.getBindingResult().getFieldErrors().forEach((error) ->
-                errors.put(error.getField(), error.getDefaultMessage()));
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
-    }
 }

--- a/src/main/java/com/sergio/usermanagement/exceptions/ErrorResponse.java
+++ b/src/main/java/com/sergio/usermanagement/exceptions/ErrorResponse.java
@@ -1,0 +1,67 @@
+package com.sergio.usermanagement.exceptions;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+
+    /**
+     * Variable para mostrar el mensaje de error.
+     * Se utiliza un Object por flexibilidad,
+     * ya que puede ser un String simple o un Map de errores de validación.
+     */
+    private Object message;
+
+    /**
+     * Variable para mapear el código de error.
+     */
+    private int status;
+
+    /**
+     * Variable para mapear el momento en que ocurrió el error.
+     */
+    private LocalDateTime timestamp;
+
+    /**
+     * Variable para mapear el tipo de error.
+     */
+    private String error;
+
+    public ErrorResponse(Object message, int status, LocalDateTime timestamp, String error) {
+        this.message = message;
+        this.status = status;
+        this.timestamp = timestamp;
+        this.error = error;
+    }
+
+    public Object getMessage() {
+        return message;
+    }
+
+    public void setMessage(Object message) {
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/src/main/java/com/sergio/usermanagement/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/sergio/usermanagement/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package com.sergio.usermanagement.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Manejador de excepciones para UserNotFoundException.
+     * Intercepta el error cuando el usuario no existe y transforma la respuesta.
+     *
+     * @param ex La excepción capturada que contiene el mensaje de error.
+     * @return ResponseEntity con el código 404 y el mensaje de error en formato JSON.
+     */
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ex.getMessage(),
+                HttpStatus.NOT_FOUND.value(),
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.getReasonPhrase()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
+     * Manejador de excepciones para MethodArgumentNotValidException
+     * Intercepta el error cuando el usuario no introduce datos válidos y transforma la respuesta.
+     *
+     * @param ex La excepción capturada que contiene el mensaje de error.
+     * @return ResponseEntity con el código 400 y el mensaje de error en formato JSON.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+
+        /*
+         * Recorre la lista de errores de validación y los agrega al mapa 'errors'
+         * siendo la clave el nombre de la variable que fallo y el valor el mensaje de error correspondiente.
+         */
+        ex.getBindingResult().getFieldErrors().forEach((error) ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                errors,
+                HttpStatus.BAD_REQUEST.value(),
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+}


### PR DESCRIPTION
### Descripción
Se ha centralizado el manejo de excepciones de la aplicación dentro de una clase global para las excepciones de los controladores. Estandariza todas las salidas de error bajo un formato JSON único y consistente.

### Cambios Realizados
- **Exceptions**:
  - Creada la clase independiente `ErrorResponse.java` con campos estandarizados: `timestamp`, `status`, `error` y `message` (declarado como `Object` para dotarlo de flexibilidad estructural).
- **Exceptions**:
  - Implementada la clase `GlobalExceptionHandler.java` anotada con `@RestControllerAdvice`.
  - Migración y refactorización del manejador de `UserNotFoundException` para empaquetar el mensaje en el nuevo molde de respuesta (404 Not Found).
  - Migración y refactorización del manejador de `MethodArgumentNotValidException` para encapsular el mapa de errores de validación (`campo: mensaje`) dentro del molde consistente (400 Bad Request).
- **Refactorización de Limpieza**:
  - Eliminados los manejadores antiguos de la clase `UserController.java`, dejando el controlador libre de lógica de excepciones.

### Pruebas y Testing (Postman)
Se ha verificado que tanto los errores de negocio como los de validación externa responden con la misma estructura exacta de datos:
- [x] **GET /api/users/{id} (Usuario inexistente)** -> Devuelve 404 Not Found encapsulado en el objeto `ErrorResponse` con mensaje en texto plano.
- [x] **POST /api/users (Datos inválidos)** -> Devuelve 400 Bad Request encapsulado en el mismo objeto `ErrorResponse`, conteniendo el mapa detallado de los campos que fallaron.

### Evidencia Visual

<img width="1087" height="604" alt="image_2026-06-04_23-09-22" src="https://github.com/user-attachments/assets/31da80b0-0d2f-417f-87d8-ea1aa359e87a" />

<img width="1083" height="661" alt="image_2026-06-04_23-16-02" src="https://github.com/user-attachments/assets/eec75c61-4c19-41ac-b191-7811d9afd8df" />


Closes #15 